### PR TITLE
add :tractor: pallet and requirements.txt reminder

### DIFF
--- a/scripts/Weekly/SureSitesPallet.py
+++ b/scripts/Weekly/SureSitesPallet.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# * coding: utf8 *
+'''
+SureSitePallet.py
+
+A forklift pallet for suresites data
+'''
+
+import requests
+from forklift import seat
+from forklift.models import Pallet
+from json import dump
+from os import makedirs
+from os.path import abspath
+from os.path import dirname
+from os.path import exists
+from os.path import join
+from time import clock
+
+data_file = join(abspath(dirname(__file__)), 'data')
+
+
+class SureSitePallet(Pallet):
+    def __init__(self):
+        super(SureSitePallet, self).__init__()
+
+    def ship(self):
+        start_seconds = clock()
+        r = requests.get('http://utahsuresites.com/rest/properties-all', timeout=30)
+        self.log.debug('utahsuresites.com receieved in %s with response code %s', seat.format_time(clock() - start_seconds), r.status_code)
+
+        r.raise_for_status()
+        sites = r.json()
+
+        if not exists(data_file):
+            makedirs(data_file)
+
+        sites_file = join(data_file, 'sites.json')
+        self.log.debug('writing to %s', sites_file)
+
+        with open(sites_file, 'w') as f:
+            dump(sites, f)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+nightly
+forklift>=4.0.0
+requests>=2.10.0


### PR DESCRIPTION
This will create a `sites.json` file to a `data` folder next to the pallet.

Since we are [generating reports](#110) and [site popups](#111) from
this data, I wanted to get it on our disk. We can modify the pallet at a later time to create the reports.

i doubt :tractor: is in pip but it's a good reminder of the python dependencies none the less.

closes #112